### PR TITLE
CI/CD-06: Create custom GitHub Action to avoid code Repeat

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,60 @@
+name: Setup
+
+description: |
+  This action sets up the php and composer environment for the workflow.
+
+inputs:
+  php-version:
+    description: The PHP version(s) to setup.
+    required: true
+  php-extensions:
+    description: The PHP extensions to install.
+    required: false
+    default: dom, curl, libxml, mbstring, zip, pcntl, pdo, gd, redis,igbinary,msgpack,lzf,zstd,lz4,memcached
+
+runs:
+  using: composite
+  steps:
+    - name: Get PHP extension cache hash
+      id: get-ext-cache-hash
+      env:
+        PHP_EXTENSIONS: ${{ inputs.php-extensions }}
+      run: echo hash=$(echo "${PHP_EXTENSIONS}" | md5sum | awk '{print $1}') >> $GITHUB_OUTPUT
+      shell: bash
+
+    # See @https://github.com/shivammathur/cache-extensions?tab=readme-ov-file#workflow
+    - name: Setup cache environment
+      id: extcache
+      uses: shivammathur/cache-extensions@v1
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.php-extensions }}
+        key: php-extensions-${{ steps.get-ext-cache-hash.outputs.hash }} # Good practice to prefix with some string
+
+    - name: Cache extensions
+      uses: actions/cache@v4.1.2
+      with:
+        path: ${{ steps.extcache.outputs.dir }}
+        key: ${{ steps.extcache.outputs.key }}
+        restore-keys: ${{ steps.extcache.outputs.key }}
+
+    # See @https://github.com/marketplace/actions/setup-php-action
+    - name: Setup PHP and Composer
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.php-extensions }}
+        tools: composer:v2
+
+    # See @https://github.com/marketplace/actions/setup-php-action#cache-composer-dependencies
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: Cache Dependencies
+      uses: actions/cache@v4.1.2
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer

--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -1,3 +1,4 @@
+# See @https://laravel.com/docs/11.x/pint#running-tests-on-github-actions
 name: Laravel Pint
 
 on:
@@ -25,11 +26,11 @@ jobs:
           ref: ${{ github.head_ref }}
 
       # See @https://github.com/marketplace/actions/setup-php-action
-      - name: Setup PHP and Composer
-        uses: shivammathur/setup-php@v2
+      - name: Setup
+        uses: ./.github/actions/setup # Use the local action
         with:
-          php-version: '8.3'
-          tools: composer:v2
+            php-version: "8.3"
+            php-extensions: "json, dom, curl, libxml, mbstring"
 
       - name: Install Laravel Pint
         run: composer global require laravel/pint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,51 +20,15 @@ jobs:
         ports:
           - 3306:3306
 
-    env:
-      PHP_VERSION: "8.3"
-      PHP_EXTENSIONS: dom, curl, libxml, mbstring, zip, pcntl, pdo, gd, redis,igbinary,msgpack,lzf,zstd,lz4,memcached
-      EXT_CACHE_KEY: cache-v1 # can be any string, change to clear the extension cache.
-
     steps:
       # See @https://github.com/marketplace/actions/checkout
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      # See @https://github.com/shivammathur/cache-extensions?tab=readme-ov-file#workflow
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
+      - name: Setup
+        uses: ./.github/actions/setup # Use the local action
         with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          key: ${{ env.EXT_CACHE_KEY }}
-
-      - name: Cache extensions
-        uses: actions/cache@v4.1.2
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
-      # See @https://github.com/marketplace/actions/setup-php-action
-      - name: Setup PHP and Composer
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          tools: composer:v2
-
-      # See @https://github.com/marketplace/actions/setup-php-action#cache-composer-dependencies
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Dependencies
-        uses: actions/cache@v4.1.2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer
+            php-version: "8.3"
 
       - name: Install Composer Dependencies
         run: composer install --prefer-dist --no-interaction --no-progress


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions setup, primarily focusing on the creation of a reusable setup action and its integration into existing workflows. The changes aim to streamline the setup process for PHP and Composer environments.

### Creation of reusable setup action:

* [`.github/actions/setup/action.yml`](diffhunk://#diff-9fb8259afcb532c9556e2d41ae1ee97cf6de54b486cef93a7ef1bf39433fa530R1-R60): Added a new composite action to set up the PHP and Composer environment, including caching mechanisms for PHP extensions and Composer dependencies.

### Integration of the new setup action:

* [`.github/workflows/laravel-pint.yml`](diffhunk://#diff-041d74ac3ab3f6b41870ce0d9461c2465a8971dbaea2fc4c5e93a6c5b5784853L28-R33): Replaced the existing setup steps with the new reusable setup action.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL23-R31): Updated the workflow to use the new reusable setup action, removing redundant environment variables and setup steps.

### Documentation references:

* [`.github/workflows/laravel-pint.yml`](diffhunk://#diff-041d74ac3ab3f6b41870ce0d9461c2465a8971dbaea2fc4c5e93a6c5b5784853R1): Added a reference link to the Laravel Pint documentation for running tests on GitHub Actions.